### PR TITLE
Add README.md with installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# DUMPI: The MPI Trace Library
+## Installation
+DUMPI uses GNU automake. For a basic installation, run
+```
+autoreconf --install
+./configure
+make
+make install
+```


### PR DESCRIPTION
While most developers can be expected to be familiar with standard make tooling, GNU automake is a lot less common and brief instructions might save the time of potential users.